### PR TITLE
ensure AB::MB is used as configure_requires

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ copyright_year   = 2014
 [AutoPrereqs]
 
 [Alien]
+:version = 0.023
 repo = file:inc
 name = gpg-error
 pattern_prefix = libgpg-error-


### PR DESCRIPTION
The latest version of the [Alien] plugin will ensure the configure requires is correctly set to `Alien::Base::ModuleBuild` instead of `Alien::Base`.  Please set https://github.com/Perl5-Alien/Alien-Base/issues/157 for rationale.
